### PR TITLE
Feature - Add "duration" and "uses" stats to module table

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@typescript-eslint/parser": "^8.24.0",
     "@vitejs/plugin-react": "^4.3.4",
     "babel-plugin-named-exports-order": "^0.0.2",
+    "dotenv-cli": "^8.0.0",
     "eslint": "^9.20.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",

--- a/src/components/tables/LaserTable.tsx
+++ b/src/components/tables/LaserTable.tsx
@@ -557,6 +557,7 @@ export const LaserTable: React.FC<LaserTableProps> = ({ onAddToLoadout }) => {
                         </TableCell>
                         <TableCell
                           sx={Object.assign({}, styles.numericCell, styles.sectionDivider, rankColors['extrPower'])}
+                          onMouseEnter={(e) => handleMouseEnter(e, theme.palette.grey[100], idr, -15)}
                         >
                           {laser.stats.extrPower}
                         </TableCell>

--- a/src/components/tables/ModuleTable.tsx
+++ b/src/components/tables/ModuleTable.tsx
@@ -33,7 +33,7 @@ import {
 } from '@regolithco/common'
 import { Bolt, Check, ClearAll, Refresh, Store } from '@mui/icons-material'
 import { fontFamilies } from '../../theme'
-import { MValue, MValueFormat } from '../fields/MValue'
+import { MValue, MValueFormat, MValueFormatter } from '../fields/MValue'
 import { LongCellHeader, LongCellHeaderProps, StatsCell, tableStylesThunk } from './tableCommon'
 import { LookupsContext } from '../../context/lookupsContext'
 import { SystemColors } from '../pages/SurveyCorps/types'
@@ -349,6 +349,12 @@ export const ModuleTable: React.FC<ModuleTableProps> = ({ onAddToLoadout }) => {
                     <LongCellHeaderWrapped theme={theme} hovered={Boolean(hoverCol && hoverCol[0] === -110)}>
                       Extract Power Mod
                     </LongCellHeaderWrapped>
+                    <LongCellHeaderWrapped theme={theme} hovered={Boolean(hoverCol && hoverCol[0] === -111)}>
+                      Uses
+                    </LongCellHeaderWrapped>
+                    <LongCellHeaderWrapped theme={theme} hovered={Boolean(hoverCol && hoverCol[0] === -112)}>
+                      Duration
+                    </LongCellHeaderWrapped>
                   </>
                 )}
                 {filteredValues.length > 0 && columnGroups.includes(ColumnGroupEnum.Market) && (
@@ -554,10 +560,32 @@ export const ModuleTable: React.FC<ModuleTableProps> = ({ onAddToLoadout }) => {
                           theme={theme}
                           value={lm.stats.extrPowerMod}
                           maxMin={maxMin['extrPowerMod']}
-                          sx={Object.assign({}, styles.sectionDivider, topBorder)}
+                          sx={topBorder}
                           onMouseEnter={(e) => handleMouseEnter(e, theme.palette.grey[100], idr, -110)}
                           reversed={BackwardStats.includes('powerMod')}
                         />
+                        <TableCell
+                          sx={Object.assign({}, styles.numericCell, topBorder)}
+                          onMouseEnter={(e) => handleMouseEnter(e, theme.palette.grey[100], idr, -111)}
+                        >
+                          {
+                            // Convert value from decimal for % display to integer
+                            lm.stats.uses && (lm.stats.uses - 1) * 100 > 0
+                              ? MValueFormatter((lm.stats.uses - 1) * 100, MValueFormat.number)
+                              : ' '
+                          }
+                        </TableCell>
+                        <TableCell
+                          sx={Object.assign({}, styles.numericCell, styles.sectionDivider, topBorder)}
+                          onMouseEnter={(e) => handleMouseEnter(e, theme.palette.grey[100], idr, -112)}
+                        >
+                          {
+                            // Convert value from decimal for % display to integer
+                            lm.stats.duration && (lm.stats.duration - 1) * 100 > 0
+                              ? `${MValueFormatter((lm.stats.duration - 1) * 100, MValueFormat.number)}s`
+                              : ' '
+                          }
+                        </TableCell>
                       </>
                     )}
 

--- a/src/components/tables/ModuleTable.tsx
+++ b/src/components/tables/ModuleTable.tsx
@@ -569,7 +569,7 @@ export const ModuleTable: React.FC<ModuleTableProps> = ({ onAddToLoadout }) => {
                           onMouseEnter={(e) => handleMouseEnter(e, theme.palette.grey[100], idr, -111)}
                         >
                           {
-                            // Convert value from decimal for % display to integer
+                            // Magic numbers: Convert value from decimal (for % display) to integer
                             lm.stats.uses && (lm.stats.uses - 1) * 100 > 0
                               ? MValueFormatter((lm.stats.uses - 1) * 100, MValueFormat.number)
                               : ' '
@@ -580,7 +580,7 @@ export const ModuleTable: React.FC<ModuleTableProps> = ({ onAddToLoadout }) => {
                           onMouseEnter={(e) => handleMouseEnter(e, theme.palette.grey[100], idr, -112)}
                         >
                           {
-                            // Convert value from decimal for % display to integer
+                            // Magic numbers: Convert value from decimal (for % display) to integer
                             lm.stats.duration && (lm.stats.duration - 1) * 100 > 0
                               ? `${MValueFormatter((lm.stats.duration - 1) * 100, MValueFormat.number)}s`
                               : ' '

--- a/yarn.lock
+++ b/yarn.lock
@@ -3385,6 +3385,7 @@ __metadata:
     axios: ^1.7.9
     babel-plugin-named-exports-order: ^0.0.2
     dayjs: ^1.11.13
+    dotenv-cli: ^8.0.0
     eslint: ^9.20.1
     eslint-config-prettier: ^9.1.0
     eslint-config-standard: ^17.1.0
@@ -6706,7 +6707,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.0, dotenv@npm:^16.3.1":
+"dotenv-cli@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "dotenv-cli@npm:8.0.0"
+  dependencies:
+    cross-spawn: ^7.0.6
+    dotenv: ^16.3.0
+    dotenv-expand: ^10.0.0
+    minimist: ^1.2.6
+  bin:
+    dotenv: cli.js
+  checksum: 9c88aa3b9976158f6c8d02918d70c3fac3ac0712c24c85db33e51eb93eb0659f86393aee233d2dd1042780ddd500f35fae4ac38f1763bbf6ce0f3f8046bc88e6
+  languageName: node
+  linkType: hard
+
+"dotenv-expand@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "dotenv-expand@npm:10.0.0"
+  checksum: 2a38b470efe0abcb1ac8490421a55e1d764dc9440fd220942bce40965074f3fb00b585f4346020cb0f0f219966ee6b4ee5023458b3e2953fe5b3214de1b314ee
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^16.0.0, dotenv@npm:^16.3.0, dotenv@npm:^16.3.1":
   version: 16.4.7
   resolution: "dotenv@npm:16.4.7"
   checksum: c27419b5875a44addcc56cc69b7dc5b0e6587826ca85d5b355da9303c6fc317fc9989f1f18366a16378c9fdd9532d14117a1abe6029cc719cdbbef6eaef2cea4


### PR DESCRIPTION
## Description
3 changes of note

1. Added dotenv-cli as a dev dependency to project (aid in standalone setup and running)
2. Fixed Extract Power column not having hover effect in Mining Lasers table (Fig. 1)
3. Added Duration and Uses stats for active modules in Mining Modules table (Fig. 2)

Fixes #: https://github.com/RegolithCo/RegolithCo-Frontend/issues/10

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Locally tested in browser.

Fig. 1 Extract Power hover effect
![image](https://github.com/user-attachments/assets/a39afcca-a8b8-49b1-b40c-822f3da7aace)

Fig. 2 Uses & Duration stats w/ hover effects
![image](https://github.com/user-attachments/assets/93590007-848f-4733-a22a-52ce85f495c2)
