### PR TITLE
Bug - Hover values remain after menu closes

### DIFF
--- a/src/components/calculators/LoadoutCalc/LoadoutCalc.tsx
+++ b/src/components/calculators/LoadoutCalc/LoadoutCalc.tsx
@@ -118,17 +118,26 @@ export const LoadoutCalc: React.FC<LoadoutCalcProps> = ({
   const [editingName, setEditingName] = React.useState(false)
   const [shareModalOpen, setShareModalOpen] = React.useState(false)
   const [newLoadout, _setNewLoadout] = React.useState<MiningLoadout>()
-  const [hoverLoadout, _setHoverLoadout] = React.useState<MiningLoadout | null>(null)
+  // const [hoverLoadout, _setHoverLoadout] = React.useState<MiningLoadout | null>(null)
   const [deleteModalOpen, setDeleteModalOpen] = React.useState(false)
   const [includeStockPrices, setIncludeStockPrices] = React.useState(false)
 
   const setNewLoadout = useCallback(
     async (sbl?: MiningLoadout) => {
       if (!newLoadout || isShare) return
-      if (hoverLoadout) _setHoverLoadout(null)
+      // if (hoverLoadout) _setHoverLoadout(null)
       const finalLoadout = sbl || (await newMiningLoadout(dataStore, newLoadout.ship as LoadoutShipEnum, owner))
       const sanitizedLoadout = await sanitizeLoadout(dataStore, finalLoadout)
       _setNewLoadout(sanitizedLoadout)
+
+      const stats = await calcLoadoutStats(dataStore, sanitizedLoadout)
+      setStats(stats)
+
+      const activeLasers = (sanitizedLoadout.activeLasers as ActiveMiningLaserLoadout[]) || []
+      const laserSize = sanitizedLoadout.ship === LoadoutShipEnum.Mole ? 2 : 1
+
+      setActiveLasers(activeLasers)
+      setLaserSize(laserSize)
     },
     [dataStore, newLoadout]
   )
@@ -136,9 +145,12 @@ export const LoadoutCalc: React.FC<LoadoutCalcProps> = ({
   const setHoverLoadout = useCallback(
     async (hl: MiningLoadout | null) => {
       if (isShare) return
-      if (hl === null) return _setHoverLoadout(null)
+      if (hl === null) return //_setHoverLoadout(null)
       const sanitizedLoadout = await sanitizeLoadout(dataStore, hl)
-      _setHoverLoadout(sanitizedLoadout)
+      // _setHoverLoadout(sanitizedLoadout)
+
+      const stats = await calcLoadoutStats(dataStore, sanitizedLoadout)
+      setStats(stats)
     },
     [dataStore]
   )
@@ -172,13 +184,10 @@ export const LoadoutCalc: React.FC<LoadoutCalcProps> = ({
   useEffect(() => {
     if (!dataStore.ready) return
     const asyncCalc = async () => {
-      const loadout = hoverLoadout || newLoadout
-      if (!loadout) return
-
-      const stats = await calcLoadoutStats(dataStore, loadout)
+      if (!newLoadout) return
+      const stats = await calcLoadoutStats(dataStore, newLoadout)
       setStats(stats)
 
-      if (!newLoadout) return
       const activeLasers = (newLoadout.activeLasers as ActiveMiningLaserLoadout[]) || []
       const laserSize = newLoadout.ship === LoadoutShipEnum.Mole ? 2 : 1
 
@@ -186,7 +195,7 @@ export const LoadoutCalc: React.FC<LoadoutCalcProps> = ({
       setLaserSize(laserSize)
     }
     asyncCalc()
-  }, [dataStore.ready, hoverLoadout, newLoadout])
+  }, [dataStore.ready])
 
   if (!dataStore.ready || !newLoadout) return <div>Loading Loadout Stats...</div>
 

--- a/src/components/calculators/LoadoutCalc/LoadoutCalc.tsx
+++ b/src/components/calculators/LoadoutCalc/LoadoutCalc.tsx
@@ -176,23 +176,16 @@ export const LoadoutCalc: React.FC<LoadoutCalcProps> = ({
         ? { ...newLoadout }
         : miningLoadout || (await newMiningLoadout(dataStore, DEFAULT_SHIP, owner))
 
-      if (!newLoadout) _setNewLoadout(myNewLoadout)
-    }
-    asyncCalc()
-  }, [dataStore.ready])
-
-  useEffect(() => {
-    if (!dataStore.ready) return
-    const asyncCalc = async () => {
-      if (!newLoadout) return
-      const stats = await calcLoadoutStats(dataStore, newLoadout)
+      const stats = await calcLoadoutStats(dataStore, myNewLoadout)
       setStats(stats)
 
-      const activeLasers = (newLoadout.activeLasers as ActiveMiningLaserLoadout[]) || []
-      const laserSize = newLoadout.ship === LoadoutShipEnum.Mole ? 2 : 1
+      const activeLasers = (myNewLoadout.activeLasers as ActiveMiningLaserLoadout[]) || []
+      const laserSize = myNewLoadout.ship === LoadoutShipEnum.Mole ? 2 : 1
 
       setActiveLasers(activeLasers)
       setLaserSize(laserSize)
+
+      if (!newLoadout) _setNewLoadout(myNewLoadout)
     }
     asyncCalc()
   }, [dataStore.ready])

--- a/src/components/calculators/LoadoutCalc/LoadoutCalc.tsx
+++ b/src/components/calculators/LoadoutCalc/LoadoutCalc.tsx
@@ -118,14 +118,12 @@ export const LoadoutCalc: React.FC<LoadoutCalcProps> = ({
   const [editingName, setEditingName] = React.useState(false)
   const [shareModalOpen, setShareModalOpen] = React.useState(false)
   const [newLoadout, _setNewLoadout] = React.useState<MiningLoadout>()
-  // const [hoverLoadout, _setHoverLoadout] = React.useState<MiningLoadout | null>(null)
   const [deleteModalOpen, setDeleteModalOpen] = React.useState(false)
   const [includeStockPrices, setIncludeStockPrices] = React.useState(false)
 
   const setNewLoadout = useCallback(
     async (sbl?: MiningLoadout) => {
       if (!newLoadout || isShare) return
-      // if (hoverLoadout) _setHoverLoadout(null)
       const finalLoadout = sbl || (await newMiningLoadout(dataStore, newLoadout.ship as LoadoutShipEnum, owner))
       const sanitizedLoadout = await sanitizeLoadout(dataStore, finalLoadout)
       _setNewLoadout(sanitizedLoadout)
@@ -145,9 +143,8 @@ export const LoadoutCalc: React.FC<LoadoutCalcProps> = ({
   const setHoverLoadout = useCallback(
     async (hl: MiningLoadout | null) => {
       if (isShare) return
-      if (hl === null) return //_setHoverLoadout(null)
+      if (hl === null) return
       const sanitizedLoadout = await sanitizeLoadout(dataStore, hl)
-      // _setHoverLoadout(sanitizedLoadout)
 
       const stats = await calcLoadoutStats(dataStore, sanitizedLoadout)
       setStats(stats)

--- a/src/components/calculators/LoadoutCalc/LoadoutLaserTool.tsx
+++ b/src/components/calculators/LoadoutCalc/LoadoutLaserTool.tsx
@@ -40,7 +40,7 @@ export const LoadoutLaserTool: React.FC<LoadoutLaserRowProps> = ({
   const previousLoadout = useRef(activeLaser)
 
   const onLaserChange = (laser: MiningLaserEnum | '', isActive: boolean, hover: boolean) => {
-    if (laser === '') return onChange(null, hover)
+    if (laser === '') return onChange(hover ? previousLoadout.current : null, hover)
     const loadout: ActiveMiningLaserLoadout = {
       laser: laser as MiningLaserEnum,
       laserActive: isActive,
@@ -49,6 +49,7 @@ export const LoadoutLaserTool: React.FC<LoadoutLaserRowProps> = ({
       __typename: 'ActiveMiningLaserLoadout',
     }
     onChange(loadout, hover)
+    // If loadout actually changed, update previous loadout value
     if (!hover) previousLoadout.current = loadout
   }
 
@@ -58,6 +59,7 @@ export const LoadoutLaserTool: React.FC<LoadoutLaserRowProps> = ({
 
   const onModuleChange = (slotIdx: number) => (module: MiningModuleEnum | '', isActive: boolean, hover: boolean) => {
     if (!hasLaser) return onChange(null, hover)
+    if (module === '' && hover) return onChange(previousLoadout.current, hover)
 
     // If the laser is off, we can't change the modules
     const newModules = Array.from({ length: slots }).map((_, idx) => {
@@ -73,17 +75,21 @@ export const LoadoutLaserTool: React.FC<LoadoutLaserRowProps> = ({
       if (idx !== slotIdx) return thisActive
       else return isActive
     })
+    const loadout: ActiveMiningLaserLoadout = {
+      laser: laserCode as MiningLaserEnum,
+      laserActive: laserIsActive || false,
+      modules: newModules,
+      modulesActive: newModulesActive,
+      __typename: 'ActiveMiningLaserLoadout',
+    }
     // Now just check that this active m is the only one that's on
-    onChange(
-      {
-        laser: laserCode as MiningLaserEnum,
-        laserActive: laserIsActive || false,
-        modules: newModules,
-        modulesActive: newModulesActive,
-        __typename: 'ActiveMiningLaserLoadout',
-      },
-      hover
-    )
+    onChange(loadout, hover)
+    // If loadout actually changed, update previous loadout value
+    if (!hover) previousLoadout.current = loadout
+  }
+
+  const onModuleClose = (isChanged: boolean) => {
+    if (!isChanged) onChange(previousLoadout.current, false)
   }
 
   if (!dataStore.ready) return null
@@ -128,6 +134,7 @@ export const LoadoutLaserTool: React.FC<LoadoutLaserRowProps> = ({
             locked={!laserIsActive}
             label="Module 1"
             onChange={onModuleChange(0)}
+            onClose={onModuleClose}
           />
         ) : (
           <ModulePlaceholder />
@@ -141,6 +148,7 @@ export const LoadoutLaserTool: React.FC<LoadoutLaserRowProps> = ({
             locked={!laserIsActive}
             label="Module 2"
             onChange={onModuleChange(1)}
+            onClose={onModuleClose}
           />
         ) : (
           <ModulePlaceholder />
@@ -154,6 +162,7 @@ export const LoadoutLaserTool: React.FC<LoadoutLaserRowProps> = ({
             locked={!laserIsActive}
             label="Module 3"
             onChange={onModuleChange(2)}
+            onClose={onModuleClose}
           />
         ) : (
           <ModulePlaceholder />

--- a/src/components/calculators/LoadoutCalc/LoadoutLaserTool.tsx
+++ b/src/components/calculators/LoadoutCalc/LoadoutLaserTool.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useRef } from 'react'
 import { Card, CardContent, CardHeader, Stack, Typography, useTheme } from '@mui/material'
 import { ActiveMiningLaserLoadout, LoadoutLookup, Maybe, MiningLaserEnum, MiningModuleEnum } from '@regolithco/common'
 import { LaserChooserMenu, ModuleChooserMenu } from './loadoutMenus'
@@ -37,18 +37,23 @@ export const LoadoutLaserTool: React.FC<LoadoutLaserRowProps> = ({
     activeModuleSelectValues.push('')
   }
 
+  const previousLoadout = useRef(activeLaser)
+
   const onLaserChange = (laser: MiningLaserEnum | '', isActive: boolean, hover: boolean) => {
     if (laser === '') return onChange(null, hover)
-    onChange(
-      {
-        laser: laser as MiningLaserEnum,
-        laserActive: isActive,
-        modules: activeLaser?.modules || [],
-        modulesActive: activeLaser?.modulesActive || [],
-        __typename: 'ActiveMiningLaserLoadout',
-      },
-      hover
-    )
+    const loadout: ActiveMiningLaserLoadout = {
+      laser: laser as MiningLaserEnum,
+      laserActive: isActive,
+      modules: activeLaser?.modules || [],
+      modulesActive: activeLaser?.modulesActive || [],
+      __typename: 'ActiveMiningLaserLoadout',
+    }
+    onChange(loadout, hover)
+    if (!hover) previousLoadout.current = loadout
+  }
+
+  const onLaserClose = (isChanged: boolean) => {
+    if (!isChanged) onChange(previousLoadout.current, false)
   }
 
   const onModuleChange = (slotIdx: number) => (module: MiningModuleEnum | '', isActive: boolean, hover: boolean) => {
@@ -111,6 +116,7 @@ export const LoadoutLaserTool: React.FC<LoadoutLaserRowProps> = ({
           isShare={isShare}
           value={laserCode || null}
           onChange={onLaserChange}
+          onClose={onLaserClose}
           isOn={laserIsActive}
         />
         {slots > 0 ? (

--- a/src/components/calculators/LoadoutCalc/loadoutMenus.tsx
+++ b/src/components/calculators/LoadoutCalc/loadoutMenus.tsx
@@ -48,11 +48,13 @@ export interface ModuleChooserMenuProps {
   isShare?: boolean
   readonly?: boolean
   onChange: (value: MiningModuleEnum | '', isActive: boolean, isHover: boolean) => void
+  onClose: (isChanged: boolean) => void
   label: string
 }
 
 export const ModuleChooserMenu: React.FC<ModuleChooserMenuProps> = ({
   onChange,
+  onClose,
   value,
   isOn,
   locked,
@@ -90,6 +92,9 @@ export const ModuleChooserMenu: React.FC<ModuleChooserMenuProps> = ({
     return 0
   })
 
+  const isChanged = useRef(false)
+  const isOpen = useRef(false)
+
   const moduleKeys: MiningModuleEnum[] = Object.keys(loadoutLookups.modules).map((key) => key as MiningModuleEnum)
   return (
     <Stack direction="row" spacing={1} paddingBottom={2}>
@@ -124,7 +129,16 @@ export const ModuleChooserMenu: React.FC<ModuleChooserMenuProps> = ({
               },
             },
           }}
-          onChange={(e) => onChange(e.target.value as MiningModuleEnum, true, false)}
+          onOpen={() => (isOpen.current = true)}
+          onChange={(e) => {
+            onChange(e.target.value as MiningModuleEnum, true, false)
+            isChanged.current = true
+          }}
+          onClose={() => {
+            isOpen.current = false
+            onClose(isChanged.current)
+            isChanged.current = false
+          }}
           renderValue={(value) => {
             if (!value) {
               return (
@@ -174,8 +188,12 @@ export const ModuleChooserMenu: React.FC<ModuleChooserMenuProps> = ({
                     idx % 2 === 0 ? theme.palette.background.paper : lighten(theme.palette.background.paper, 0.05),
                 }}
                 value={module.code}
-                onMouseOut={() => onChange('', true, true)}
-                onMouseOver={() => onChange(module.code as MiningModuleEnum, true, true)}
+                onMouseOut={() => {
+                  if (isOpen.current) onChange('', true, true)
+                }}
+                onMouseOver={() => {
+                  if (isOpen.current) onChange(module.code as MiningModuleEnum, true, true)
+                }}
               >
                 <ModuleMenuItem moduleCode={key} />
               </MenuItem>,
@@ -201,8 +219,12 @@ export const ModuleChooserMenu: React.FC<ModuleChooserMenuProps> = ({
                     idx % 2 === 0 ? theme.palette.background.paper : lighten(theme.palette.background.paper, 0.05),
                 }}
                 value={module.code}
-                onMouseOut={() => onChange('', true, true)}
-                onMouseOver={() => onChange(module.code as MiningModuleEnum, true, true)}
+                onMouseOut={() => {
+                  if (isOpen.current) onChange('', true, true)
+                }}
+                onMouseOver={() => {
+                  if (isOpen.current) onChange(module.code as MiningModuleEnum, true, true)
+                }}
               >
                 <ModuleMenuItem moduleCode={key} />
               </MenuItem>,

--- a/src/components/calculators/LoadoutCalc/loadoutMenus.tsx
+++ b/src/components/calculators/LoadoutCalc/loadoutMenus.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useRef } from 'react'
 import { Box, ListSubheader, MenuItem, Select, Stack, Typography, lighten, useTheme } from '@mui/material'
 import {
   AllStats,
@@ -219,6 +219,7 @@ export interface LaserChooserMenuProps {
   isOn?: boolean
   isShare?: boolean
   onChange: (value: MiningLaserEnum | '', isActive: boolean, isHover: boolean) => void
+  onClose: (isChanged: boolean) => void
   readonly?: boolean
   laserSize: number
 }
@@ -227,6 +228,7 @@ const LASER_NO_MENU_STAT: (keyof AllStats)[] = ['shatterDamage', 'overchargeRate
 
 export const LaserChooserMenu: React.FC<LaserChooserMenuProps> = ({
   onChange,
+  onClose,
   value,
   laserSize,
   isOn,
@@ -252,6 +254,9 @@ export const LaserChooserMenu: React.FC<LaserChooserMenuProps> = ({
     if (laserA.name < laserB.name) return -1
     return 0
   })
+
+  const isChanged = useRef(false)
+  const isOpen = useRef(false)
 
   return (
     <Stack direction="row" spacing={1} paddingBottom={2}>
@@ -285,7 +290,16 @@ export const LaserChooserMenu: React.FC<LaserChooserMenuProps> = ({
               },
             },
           }}
-          onChange={(e) => onChange(e.target.value as MiningLaserEnum, true, false)}
+          onOpen={() => (isOpen.current = true)}
+          onChange={(e) => {
+            onChange(e.target.value as MiningLaserEnum, true, false)
+            isChanged.current = true
+          }}
+          onClose={() => {
+            isOpen.current = false
+            onClose(isChanged.current)
+            isChanged.current = false
+          }}
           renderValue={(laserCode) => {
             if (!laserCode) {
               return (
@@ -338,8 +352,12 @@ export const LaserChooserMenu: React.FC<LaserChooserMenuProps> = ({
               <MenuItem
                 key={`menu${key}-${idx}`}
                 value={key}
-                onMouseOut={() => onChange('', true, true)}
-                onMouseOver={() => onChange(key, true, true)}
+                onMouseOut={() => {
+                  if (isOpen.current) onChange('', true, true)
+                }}
+                onMouseOver={() => {
+                  if (isOpen.current) onChange(key, true, true)
+                }}
                 sx={{
                   backgroundColor:
                     idx % 2 === 0 ? theme.palette.background.paper : lighten(theme.palette.background.paper, 0.05),


### PR DESCRIPTION
## Description

Resolved issue where, depending on what the cursor hovered over last, stat block would not display correct stats for current loadout. This would occur in scenarios where, as the dropdown options are closing out, the cursor might hit another element in said dropdown and stats would display for that. This would also occur if the dropdown options were open, but the cursor moved outside the dropdown.  Now stat block will correctly display the currently selected loadout stats at any point when the cursor is not actively hovering over another option in the dropdown options.

Fixes #: #16 (partial)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Open Mining Loadout Calculator
2. Open laser or module dropdown options
3. Select a laser or module and quickly cursor over an item different than the one selected
4. Notice stat block displays the selected item stats instead of the last hovered item stats
5. Open laser or module dropdown options
6. Cursor outside the dropdown options (do not click)
7. Notice stat block displays the still selected item stats instead of nulling out the selection
8. Click outside the dropdown options, causing it to close without making a change
9. Notice the stat block properly displays selected item stats instead of last hovered or nulled out stats