### PR TITLE
Bug - Loadout prices showing as zero

### DIFF
--- a/src/components/calculators/LoadoutCalc/loadoutMenus.tsx
+++ b/src/components/calculators/LoadoutCalc/loadoutMenus.tsx
@@ -366,7 +366,7 @@ export const LaserMenuItem: React.FC<LaserMenuItemProps> = ({ laserCode }) => {
   const loadoutLookups = dataStore.getLookup('loadout') as LoadoutLookup
   if (!dataStore.ready) return null
   const laser = loadoutLookups.lasers[laserCode as MiningLaserEnum]
-  const allPrices = (Object.values(laser.prices) as number[]) || [0]
+  const allPrices = (Object.values(laser.prices).filter((price) => price > 0) as number[]) || [0]
   const minPrice = Math.min(...allPrices)
 
   return (
@@ -420,7 +420,7 @@ export const ModuleMenuItem: React.FC<ModuleMenuItemProps> = ({ moduleCode }) =>
     loadoutLookups.modules[moduleCode as MiningModuleEnum] || loadoutLookups.gadgets[moduleCode as MiningGadgetEnum]
   if (!module) return null
   const isGadget = module.category === 'G'
-  const allPrices = (Object.values(module.prices) as number[]) || [0]
+  const allPrices = (Object.values(module.prices).filter((price) => price > 0) as number[]) || [0]
   const minPrice = Math.min(...allPrices)
   return (
     <>


### PR DESCRIPTION
## Description

Some mining heads and modules were listing their price as 0 aUEC. Added a filter to remove "0" values from prices as these can generally be presumed to represent incomplete data from UEX.

Fixes #: #16 (partial)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Fig. 1
![image](https://github.com/user-attachments/assets/13cd2be8-5aae-4eae-86b8-dc89acd3ee17)

Fig. 2
![image](https://github.com/user-attachments/assets/a03c5881-19f0-4ae2-9988-5c6099f94d43)